### PR TITLE
Ensure .env files are untracked using git rm --cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository provides a custom pre-commit hook that identifies `.env*` files 
     ```yaml
     repos:
       - repo: https://github.com/nicballarini/env-sanitizer
-        rev: v1.0.4
+        rev: v1.0.5
         hooks:
           - id: sanitize-env-files
     ```

--- a/sanitize-env-hook.sh
+++ b/sanitize-env-hook.sh
@@ -33,8 +33,11 @@ process_env_file() {
     echo "$env_file" >> .gitignore
   fi
 
-  # Stage the .EXAMPLE file for the commit
+  # Stage the .EXAMPLE file for commit, even if .env file isn't staged
   git add "$example_file"
+
+  # Remove the .env file from staging, so it isn't accidentally committed
+  git rm --cached "$env_file"
 }
 
 # Find all .env files including .env.<environment>, excluding .EXAMPLE files


### PR DESCRIPTION
### v1.0.5 - Ensure `.env` Files are Untracked

This release introduces a safeguard to prevent `.env` files from being accidentally staged and committed. After generating or updating the `.EXAMPLE` files, the `.env` files are automatically removed from Git's staging area, ensuring they remain untracked.

#### Features:
- **`git rm --cached` for `.env` Files**: Automatically untracks `.env` files after processing, ensuring they are not committed unless explicitly staged again.
- **Consistent `.EXAMPLE` Updates**: `.EXAMPLE` files are still generated and staged for commit, keeping environment examples up to date.

This change ensures `.env` files remain private and out of the Git history while maintaining updated `.EXAMPLE` files.
